### PR TITLE
Fix Workflow class hierarchy

### DIFF
--- a/src/main/kotlin/org/objectionary/ddr/launch/DdrWorkflow.kt
+++ b/src/main/kotlin/org/objectionary/ddr/launch/DdrWorkflow.kt
@@ -29,6 +29,7 @@ interface Workflow {
 abstract class XmirAnalysisWorkflow(val documents: MutableMap<Document, String>) : Workflow {
     /** @property graph decoration hierarchy graph of xmir files from analyzed directory */
     protected val graph = GraphBuilder(documents).createGraph()
+
     /**
      * Aggregates all steps of analysis
      */
@@ -37,11 +38,11 @@ abstract class XmirAnalysisWorkflow(val documents: MutableMap<Document, String>)
 
 /**
  * Stores all the information from xmir files in the form of a graph. Launches analysis and transformation steps for
- * the "Dynamic Dispatch Removal" on this graph.
+ * the Dynamic Dispatch Removal on this graph.
  *
- * @property documents all documents from analyzed directory
+ * @param documents all documents from analyzed directory
  */
-class DdrWorkflow(documents: MutableMap<Document, String>): XmirAnalysisWorkflow(documents) {
+class DdrWorkflow(documents: MutableMap<Document, String>) : XmirAnalysisWorkflow(documents) {
     /**
      * Constructs [documents] from [path]
      *
@@ -52,7 +53,7 @@ class DdrWorkflow(documents: MutableMap<Document, String>): XmirAnalysisWorkflow
         SrsTransformed(path, XslTransformer(), postfix, false).walk())
 
     /**
-     * Aggregates all steps of analysis
+     * Aggregates all steps of Dynamic Dispatch Removal
      */
     override fun launch() {
         CondAttributesSetter(graph).processConditions()

--- a/src/main/kotlin/org/objectionary/ddr/launch/DdrWorkflow.kt
+++ b/src/main/kotlin/org/objectionary/ddr/launch/DdrWorkflow.kt
@@ -11,15 +11,37 @@ import org.objectionary.ddr.transform.impl.CondNodesResolver
 import org.w3c.dom.Document
 
 /**
+ * Workflow of some software application.
+ */
+interface Workflow {
+    /**
+     * Starts the entire workflow.
+     */
+    fun launch()
+}
+
+/**
  * Stores all the information from xmir files in the form of a graph. Launches various analysis or transformation steps
- * on the graph.
+ * on this graph.
  *
  * @property documents all documents from analyzed directory
  */
-class DdrWorkflow(val documents: MutableMap<Document, String>) {
+abstract class XmirAnalysisWorkflow(val documents: MutableMap<Document, String>) : Workflow {
     /** @property graph decoration hierarchy graph of xmir files from analyzed directory */
-    private val graph = GraphBuilder(documents).createGraph()
+    protected val graph = GraphBuilder(documents).createGraph()
+    /**
+     * Aggregates all steps of analysis
+     */
+    abstract override fun launch()
+}
 
+/**
+ * Stores all the information from xmir files in the form of a graph. Launches analysis and transformation steps for
+ * the "Dynamic Dispatch Removal" on this graph.
+ *
+ * @property documents all documents from analyzed directory
+ */
+class DdrWorkflow(documents: MutableMap<Document, String>): XmirAnalysisWorkflow(documents) {
     /**
      * Constructs [documents] from [path]
      *
@@ -32,7 +54,7 @@ class DdrWorkflow(val documents: MutableMap<Document, String>) {
     /**
      * Aggregates all steps of analysis
      */
-    fun launch() {
+    override fun launch() {
         CondAttributesSetter(graph).processConditions()
         AttributesSetter(graph).setAttributes()
         InnerPropagator(graph).propagateInnerAttrs()

--- a/src/test/kotlin/org/objectionary/ddr/integration/IntegrationDdrWorkflowBase.kt
+++ b/src/test/kotlin/org/objectionary/ddr/integration/IntegrationDdrWorkflowBase.kt
@@ -36,7 +36,7 @@ import java.nio.file.Paths
 /**
  * Base class for testing decorators resolver
  */
-open class IntegrationDdrLaunchedBase : TestBase {
+open class IntegrationDdrWorkflowBase : TestBase {
     private val logger = LoggerFactory.getLogger(this.javaClass.name)
 
     override fun doTest() {

--- a/src/test/kotlin/org/objectionary/ddr/integration/IntegrationDdrWorkflowTest.kt
+++ b/src/test/kotlin/org/objectionary/ddr/integration/IntegrationDdrWorkflowTest.kt
@@ -3,7 +3,7 @@ package org.objectionary.ddr.integration
 import org.junit.jupiter.api.Test
 import kotlin.test.Ignore
 
-class IntegrationDdrWorkflowTest : IntegrationDdrLaunchedBase() {
+class IntegrationDdrWorkflowTest : IntegrationDdrWorkflowBase() {
     @Test
     @Ignore
     fun `test fibonacci`() = doTest()


### PR DESCRIPTION
closes #117

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on renaming and restructuring classes and interfaces related to the workflow in the codebase.

### Detailed summary:
- Renamed `IntegrationDdrLaunchedBase` to `IntegrationDdrWorkflowBase`.
- Renamed `DdrWorkflow` to `XmirAnalysisWorkflow`.
- Added a new interface `Workflow` with a `launch()` function.
- Updated `DdrWorkflow` to extend `XmirAnalysisWorkflow` and implement `Workflow`.
- Updated the `launch()` function in `DdrWorkflow` to override the one in `XmirAnalysisWorkflow`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->