### PR TITLE
Fix bug in test

### DIFF
--- a/src/test/kotlin/org/objectionary/ddr/integration/resolver/ResolverBase.kt
+++ b/src/test/kotlin/org/objectionary/ddr/integration/resolver/ResolverBase.kt
@@ -75,7 +75,7 @@ open class ResolverBase : IntegrationTestBase {
             .forEach { file ->
                 val expected = File(file.toString()).bufferedReader().use { it.readText().replace(" ", "") }
                 val actual = File(
-                    file.toString().replace("$eoOutTmp$sep", "out$sep")
+                    file.toString().replace("out$sep", "$eoOutTmp$sep")
                 ).bufferedReader().use { it.readText().replace(" ", "") }
                 checkOutput(expected, actual)
             }


### PR DESCRIPTION
Due to this bug the `Resolver` test was always passed. The expected files were always compared with themselves. 

This PR fixes it.